### PR TITLE
[Seminar1] 선택 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    implementation 'com.ibm.icu:icu4j:73.2'
 }
 
 test {

--- a/src/main/java/org/sopt/seminar1/Validator.java
+++ b/src/main/java/org/sopt/seminar1/Validator.java
@@ -1,5 +1,6 @@
 package org.sopt.seminar1;
 
+import com.ibm.icu.text.BreakIterator;
 import org.sopt.seminar1.Main.UI.DiaryLengthExceededException;
 import org.sopt.seminar1.Main.UI.InvalidInputException;
 
@@ -15,10 +16,25 @@ public class Validator {
     }
 
     static void validateLength(final String input) {
-        if (input.length() > MAX_DIARY_LENGTH) {
-            System.out.print(input.length() + "자네요! ");
+        int inputLength = countGraphemeClusters(input);
+
+        if (inputLength > MAX_DIARY_LENGTH) {
+            System.out.print(inputLength + "자네요! ");
 
             throw new DiaryLengthExceededException();
         }
+    }
+
+    private static int countGraphemeClusters(final String input) {
+        BreakIterator iterator = BreakIterator.getCharacterInstance();
+        iterator.setText(input);
+
+        int count = 0;
+
+        while (BreakIterator.DONE != iterator.next()) {
+            count++;
+        }
+
+        return count;
     }
 }


### PR DESCRIPTION
# 💡 Issue
1차 세미나 선택 과제를 구현합니다.
- [ ] 삭제된 일기 복구 기능 추가 ⭐️⭐️
- [ ] 일기 수정 일일 2회 제한 기능 추가 ⭐️⭐️
- [ ] Application 종료 시에도 일기 저장 목록이 유지되는 기능 추가 ⭐️⭐️⭐️
- [X] 일기 글자수 제한은 유지하면서, 이모지와 같이 사용자가 `하나의 문자`로 인식하는 문자를 1글자로 계산하는 기능 추가 ⭐️⭐️⭐️⭐️⭐️

<br>

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
<img width="357" alt="image" src="https://github.com/user-attachments/assets/53bfe88b-ad40-4146-b744-da40b9d76553">

<br>

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
Java에서 `String`의 `length()` 메서드는 UTF-16 코드 단위(16비트 단위)의 개수를 반환합니다.
이는 각 유니코드 문자들이 몇 개의 코드 단위로 표현되는지에 따라 값이 달라질 수 있는데요.

이에 처음엔 유니코드 코드 포인트의 개수를 세어주는 `String`의 `codePointCount()` 메서드를 사용하여 글자수를 계산하고자 했습니다.

> 👋와 같은 이모지는 서로게이트 페어로 표현되어, 2개의 UTF-16 코드 단위로 계산되므로 `length()`에서는 2글자로 계산되지만,
`codePointCount()`에서는 이를 하나의 유니코드 코드 포인트로 인식하여 1글자로 계산됩니다. (서로게이트 페어가 올바르게 구성된 경우)

<br>

하지만 해당 메서드를 사용해 `안녕하세요30자test입니다🫡 이모지도1글자로칩니다!👍🏻` 라는 30자 input을 넣어보니 31자로 계산되었는데요..

<br>

## 알고 보니 조합형 이모지라는 녀석이 있었습니다..

'👍🏻'은 단일 이모지로 보이지만, 사실 다음과 같은 두 개의 유니코드 코드 포인트로 구성되어 있습니다.

> 👍 (Thumbs Up) - 코드 포인트 U+1F44D
🏻 (Light Skin Tone Modifier) - 코드 포인트 U+1F3FB

<br>

이러한 조합형 이모지는 실제론 두 개의 코드 포인트로 구성되어 있으므로, `codePointCount()`를 사용하면 두 개의 문자로 계산됩니다..

<br>

### Grapheme Cluster

따라서 해당 이슈를 해결하기 위해 `Grapheme Cluster` 개념을 사용하기로 했습니다 !

> `Grapheme Cluster`는 사용자가 `하나의 문자`로 인식하는 문자 단위로,
여러 개의 유니코드 코드 포인트가 결합된 조합형 이모지를 단일 문자로 취급할 수 있게 해줍니다.

<br>

이를 위해 `ICU4J(International Components for Unicode for Java)` 라이브러리를 추가했구요,
해당 라이브러리의 `BreakIterator`를 사용해 `Grapheme Cluster` 단위로 문자열을 계산했습니다 ~!

> `BreakIterator`는 텍스트에서 문자를 분리하는 데 사용되는 유틸리티로,
각 `Grapheme Cluster`의 경계를 자동으로 인식하여, 여러 유니코드 코드 포인트로 구성된 문자도 한 문자로 처리합니다.

기존에는 Java 표준 라이브러리에도 `BreakIterator`가 존재해 이걸 사용하려 했으나,
이녀석은 ICU4J의 `BreakIterator`만큼 강력하진 않아 조합형 이모지를 여전히 2개의 코드 포인트로 계산하더라구요.. 아쉽 ~

<br>

아래 둘의 차이점을 간단히 정리한 표를 공유합니다 ~!

| 특징 | ICU4J | BreakIterator |
| :---: | --- | --- |
| **유니코드 버전 지원** | 최신 유니코드 표준을 빠르게 지원 | 업데이트가 느리고 최신 유니코드 지원 부족 |
| **Grapheme Cluster** | 복잡한 이모지 조합과 변형을 완벽히 처리 | 기본적인 Grapheme Cluster만 처리 |
| **이모지 지원** | 변형 선택자 및 조합형 이모지 완벽 지원 | 일부 이모지를 개별 문자로 처리할 가능성 |
| **국제화 지원** | 다양한 로캘(Locale)과 다국어 문자 지원 | 라틴 문자에 최적화 |
| **기능성** | 문자열 비교, 정렬 등 다양한 기능 제공 | 문자, 단어, 문장 경계 탐지에 초점 |

<br>

## 세부 구현

1. `getCharacterInstance()` 메서드를 통해 텍스트를 `Grapheme Cluster` 단위로 분할할 수 있는 BreakIterator 객체를 생성합니다.
2. 글자수를 분석할 텍스트(input)를 `BreakIterator`에 할당합니다.
3. `iterator.next()`를 통해 다음 `Grapheme Cluster`이 존재하지 않을 때까지 반복합니다.

https://github.com/AND-SOPT-SERVER/changkyun.kim/blob/34021008918a9c4c47182bbe5ac25017c233ff0d/src/main/java/org/sopt/seminar1/Validator.java#L28-L39

<br>

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 1주차라 PR에 힘을 좀 줘봤습니다..
- 이해가 되지 않는 부분이 있다면 코멘트 남겨주세요.